### PR TITLE
FIX: Rails 6.1 Deprecates update_attributes

### DIFF
--- a/app/controllers/plug/features_controller.rb
+++ b/app/controllers/plug/features_controller.rb
@@ -39,7 +39,7 @@ module Plug
 
     # PATCH/PUT /features/1
     def update
-      if @feature.update_attributes(feature_params)
+      if @feature.update(feature_params)
         redirect_to features_path, notice: 'Feature was successfully updated.'
       else
         render :edit

--- a/app/controllers/plug/site_notices_controller.rb
+++ b/app/controllers/plug/site_notices_controller.rb
@@ -39,7 +39,7 @@ module Plug
 
     # PATCH/PUT /site_notices/1
     def update
-      if @site_notice.update_attributes(site_notice_params)
+      if @site_notice.update(site_notice_params)
         redirect_to site_notices_path, notice: 'Site Notice was successfully updated.'
       else
         render :edit


### PR DESCRIPTION
Acceptance Criteria
=================
- Rails 6.1 Deprecates update_attributes

Solution
=================
- Using update instead

Checklist
=================
- [ ] [ ] Pull Request should have a descriptive title
- [ ] [ ] Code is understandable without Dev
- [ ] [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] [ ] All new methods have a relevant spec